### PR TITLE
Add Admin Mode: teacher login and protect signup/unregister

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+requests

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,35 +4,71 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const closeLogin = document.getElementById("close-login");
+
+  function showMessage(text, type = "info") {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+  }
+
+  function isTeacherLoggedIn() {
+    return !!localStorage.getItem("token");
+  }
+
+  function updateUIForAuth() {
+    const loggedIn = isTeacherLoggedIn();
+    if (loggedIn) {
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      signupForm.classList.add("hidden");
+    } else {
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      signupForm.classList.remove("hidden");
+    }
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
       const response = await fetch("/activities");
       const activities = await response.json();
 
-      // Clear loading message
+      // Clear loading message and activity select
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = "<option value=''>-- Select an activity --</option>";
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
 
-        const spotsLeft =
-          details.max_participants - details.participants.length;
+        const spotsLeft = details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
+        // Show delete button only for logged in teachers
+        const deleteButtons = isTeacherLoggedIn()
+          ? details.participants
+              .map(
+                (email) =>
+                  `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+              )
+              .join("")
+          : details.participants
+              .map((email) => `<li><span class="participant-email">${email}</span></li>`)
+              .join("");
+
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
               <h5>Participants:</h5>
               <ul class="participants-list">
-                ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
+                ${deleteButtons}
               </ul>
             </div>`
             : `<p><em>No participants yet</em></p>`;
@@ -56,10 +92,12 @@ document.addEventListener("DOMContentLoaded", () => {
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
+      // Add event listeners to delete buttons (if any)
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
+
+      updateUIForAuth();
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -67,94 +105,132 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  // Handle unregister functionality
+  // Handle unregister functionality (teachers only)
   async function handleUnregister(event) {
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
 
+    const token = localStorage.getItem("token");
+    if (!token) {
+      showMessage("Teacher login required to perform this action.", "error");
+      return;
+    }
+
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-
+        showMessage(result.message, "success");
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
 
-  // Handle form submission
+  // Handle form submission (teachers only)
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
+    const token = localStorage.getItem("token");
+    if (!token) {
+      showMessage("Teacher login required to perform this action.", "error");
+      return;
+    }
+
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/signup?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
-
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  // Login/logout flow
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+  });
+
+  closeLogin.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok && result.token) {
+        localStorage.setItem("token", result.token);
+        loginModal.classList.add("hidden");
+        showMessage("Logged in as teacher", "success");
+        fetchActivities();
+      } else {
+        showMessage(result.detail || "Invalid credentials", "error");
+      }
+    } catch (error) {
+      showMessage("Failed to log in. Please try again.", "error");
+      console.error("Login error:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
+
+    try {
+      await fetch("/logout", { method: "POST", headers: { Authorization: `Bearer ${token}` } });
+    } catch (e) {
+      // ignore
+    }
+    localStorage.removeItem("token");
+    showMessage("Logged out", "info");
+    fetchActivities();
+  });
+
   // Initialize app
+  updateUIForAuth();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,10 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth" class="auth-controls">
+        <button id="login-btn">Login</button>
+        <button id="logout-btn" class="hidden">Logout</button>
+      </div>
     </header>
 
     <main>
@@ -40,6 +44,21 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <form id="login-form" class="modal-content">
+        <h4>Teacher Login</h4>
+        <label for="username">Username</label>
+        <input type="text" id="username" required />
+        <label for="password">Password</label>
+        <input type="password" id="password" required />
+        <div style="margin-top:10px">
+          <button type="submit">Login</button>
+          <button type="button" id="close-login">Cancel</button>
+        </div>
+      </form>
+    </div>
 
     <footer>
       <p>&copy; 2023 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -198,3 +198,39 @@ footer {
   padding: 20px;
   color: #666;
 }
+
+/* Auth and modal styles */
+.auth-controls {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 6px;
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.modal input[type="text"],
+.modal input[type="password"] {
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher",
+      "password": "password123"
+    }
+  ]
+}

--- a/tests/test_admin_mode.py
+++ b/tests/test_admin_mode.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+from src.app import app, sessions
+
+client = TestClient(app)
+
+def test_login_and_protected_endpoints():
+    # Login with known teacher
+    resp = client.post("/login", json={"username": "teacher", "password": "password123"})
+    assert resp.status_code == 200
+    token = resp.json().get("token")
+    assert token
+
+    # Try to signup without token -> should be 403
+    resp2 = client.post("/activities/Chess Club/signup?email=test@student.edu")
+    assert resp2.status_code == 403
+
+    # Sign up with token
+    headers = {"Authorization": f"Bearer {token}"}
+    resp3 = client.post("/activities/Chess Club/signup?email=test@student.edu", headers=headers)
+    assert resp3.status_code == 200
+    assert "Signed up test@student.edu" in resp3.json().get("message", "")
+
+    # Unregister with token
+    resp4 = client.delete("/activities/Chess Club/unregister?email=test@student.edu", headers=headers)
+    assert resp4.status_code == 200
+    assert "Unregistered test@student.edu" in resp4.json().get("message", "")
+
+    # Logout and ensure token invalidated
+    client.post("/logout", headers=headers)
+    assert token not in sessions


### PR DESCRIPTION
This PR adds a simple teacher authentication flow and restricts activity registration and unregistration to logged-in teachers.

Changes:
- Add `src/teachers.json` with sample credentials
- Add `/login` and `/logout` endpoints and token-based sessions
- Require Bearer token for `POST /activities/{activity}/signup` and `DELETE /activities/{activity}/unregister`
- Add UI for teacher login and adapt frontend to only show registration controls to logged-in teachers
- Add tests to verify authentication and protected endpoints

Note: This keeps credentials in a JSON file (per exercise instruction). For production use, replace with a secure store and hashed passwords.